### PR TITLE
refactor(math): redefine world coordinates to zoom-16 pre-scaled space

### DIFF
--- a/packages/math/src/Tiler.ts
+++ b/packages/math/src/Tiler.ts
@@ -19,7 +19,7 @@ export interface Tile {
   id: string;
   /** tile coordinate array ex. [0,0,0] */
   xyz: Vec3;
-  /** Extent in world coordinates (x,y) */
+  /** Extent in world coordinates (z16 scale, range 0..16_777_216) */
   tileExtent: Extent;
   /** Extent in WGS84 coordinates(lon,lat) */
   wgs84Extent: Extent;
@@ -183,8 +183,8 @@ export class Tiler {
     const zOrig = t.z - adjust;
     const z = numClamp(Math.round(zOrig), this._zoomRange[0], this._zoomRange[1]);
     const pow2z = Math.pow(2, z);
-    const worldScale = pow2z / 256;
-    const tileScale = 256 / pow2z;
+    const worldScale = pow2z / 16_777_216;
+    const tileScale = 16_777_216 / pow2z;
     const min = 0;
     const max = pow2z - 1;
 

--- a/packages/math/src/Viewport.ts
+++ b/packages/math/src/Viewport.ts
@@ -10,6 +10,13 @@ import { Transform, TransformProps } from './Transform';
 import { Vec2, vecRotate, vecScale, vecCeil } from './vector';
 
 
+/** World size in world coordinates: 256 × 2^16
+ *  World coordinates are pre-scaled to zoom 16, so the full world spans [0, 0] to [WORLD_SIZE, WORLD_SIZE].
+ */
+const WORLD_SIZE = 256 * 65536;   // 16_777_216
+const WORLD_HALF = WORLD_SIZE / 2; // 8_388_608 — the Mercator origin (Null Island)
+
+
 /** `Viewport` is a class for managing the state of the viewer
  *   and converting between Lon/Lat (λ,φ) and Cartesian (x,y) coordinates
  *
@@ -19,8 +26,9 @@ import { Vec2, vecRotate, vecScale, vecCeil } from './vector';
  *
  *  Some nomenclature on the coordinates that this code uses:
  *  - "WGS84 coordinates" - These are Lon/Lat (λ,φ)
- *  - "world coordinates" - These are Mercator projected into Cartesian (x,y) but not transformed
- *     - origin puts [0,0] at top left of world and [256, 256] at bottom right of world.
+ *  - "world coordinates" - These are Mercator projected into Cartesian (x,y) and pre-scaled to zoom 16
+ *     - origin puts [0,0] at top left of world and [16_777_216, 16_777_216] (256 × 2^16) at bottom right.
+ *     - pre-scaling to z16 means geometry projected once can be rendered at any zoom without recalculating.
  *  - "screen coordinates" - These are the Cartesian coordinates with view transform applied
  *     - origin puts [0,0] at top left of screen and they are in pixels
  *
@@ -140,9 +148,9 @@ export class Viewport {
    * @returns  The world coordinate (x,y)
    */
   wgs84ToWorld(loc: Vec2): Vec2 {
-    const x = (loc[0] + 180) / 360 * 256;
+    const x = (loc[0] + 180) / 360 * WORLD_SIZE;
     const phi = numClamp(loc[1] * DEG2RAD, MIN_PHI, MAX_PHI);
-    const y = ((1 - Math.log(Math.tan(phi) + 1 / Math.cos(phi)) / Math.PI) / 2) * 256;
+    const y = ((1 - Math.log(Math.tan(phi) + 1 / Math.cos(phi)) / Math.PI) / 2) * WORLD_SIZE;
     return [x, y];
   }
 
@@ -153,8 +161,8 @@ export class Viewport {
    * @returns  The WGS84 coordinate Lon/Lat (λ,φ)
    */
   worldToWgs84(world: Vec2): Vec2 {
-    const lon = (world[0] / 256) * 360 - 180;
-    const n = Math.PI - TAU * (world[1] / 256);
+    const lon = (world[0] / WORLD_SIZE) * 360 - 180;
+    const n = Math.PI - TAU * (world[1] / WORLD_SIZE);
     const phi = Math.atan(0.5 * (Math.exp(n) - Math.exp(-n)));
     const lat = numClamp(phi, MIN_PHI, MAX_PHI) * RAD2DEG;
     return [lon, lat];
@@ -168,11 +176,11 @@ export class Viewport {
    */
   worldToScreen(world: Vec2, includeRotation?: boolean): Vec2 {
     const { x, y, z, r } = this._transform;
-    const scale = Math.pow(2, z);
+    const scale = Math.pow(2, z - 16);  // world coords are pre-scaled to z16
 
     const point: Vec2 = [
-      ((world[0] - 128) * scale) + x,
-      ((world[1] - 128) * scale) + y
+      ((world[0] - WORLD_HALF) * scale) + x,
+      ((world[1] - WORLD_HALF) * scale) + y
     ];
 
     if (includeRotation && r) {
@@ -195,10 +203,10 @@ export class Viewport {
       screen = vecRotate(screen, -r, this.center());
     }
 
-    const scale = Math.pow(2, z);
+    const scale = Math.pow(2, z - 16);  // world coords are pre-scaled to z16
     const point: Vec2 = [
-      ((screen[0] - x) / scale) + 128,
-      ((screen[1] - y) / scale) + 128
+      ((screen[0] - x) / scale) + WORLD_HALF,
+      ((screen[1] - y) / scale) + WORLD_HALF
     ];
     return point;
   }

--- a/packages/math/test/Tiler.test.js
+++ b/packages/math/test/Tiler.test.js
@@ -52,8 +52,8 @@ describe('math/tiler', () => {
         assert.ok(tileExtent instanceof Extent);
         assert.equal(tileExtent.min[0], 0);
         assert.equal(tileExtent.min[1], 0);
-        assert.equal(tileExtent.max[0], 256);
-        assert.equal(tileExtent.max[1], 256);
+        assert.equal(tileExtent.max[0], 16777216);
+        assert.equal(tileExtent.max[1], 16777216);
       });
 
       it(`tiles have a wgs84Extent property (z=0, tileSize=${tileSize})`, () => {
@@ -112,8 +112,8 @@ describe('math/tiler', () => {
         expected.forEach((xyz, i) => {
           const [x, y, z] = xyz;
           const tileExtent = tiles[i].tileExtent;
-          const tileScale = 256 / Math.pow(2, z);
-          assert.equal(tileExtent.min[0], x * tileScale);    // 0..128..256
+          const tileScale = 16777216 / Math.pow(2, z);
+          assert.equal(tileExtent.min[0], x * tileScale);    // 0..8388608..16777216
           assert.equal(tileExtent.min[1], y * tileScale);
           assert.equal(tileExtent.max[0], (x + 1) * tileScale);
           assert.equal(tileExtent.max[1], (y + 1) * tileScale);
@@ -190,8 +190,8 @@ describe('math/tiler', () => {
         expected.forEach((xyz, i) => {
           const [x, y, z] = xyz;
           const tileExtent = tiles[i].tileExtent;
-          const tileScale = 256 / Math.pow(2, z);
-          assert.equal(tileExtent.min[0], x * tileScale);    // 0..64..128..192..256
+          const tileScale = 16777216 / Math.pow(2, z);
+          assert.equal(tileExtent.min[0], x * tileScale);    // 0..4194304..8388608..12582912..16777216
           assert.equal(tileExtent.min[1], y * tileScale);
           assert.equal(tileExtent.max[0], (x + 1) * tileScale);
           assert.equal(tileExtent.max[1], (y + 1) * tileScale);

--- a/packages/math/test/Viewport.test.js
+++ b/packages/math/test/Viewport.test.js
@@ -179,53 +179,53 @@ describe('math/viewport', () => {
   describe('#wgs84ToWorld', () => {
     const view = new Viewport();
 
-    it(`Projects [0°, 0°] -> [128, 128]`, () => {
+    it(`Projects [0°, 0°] -> [8388608, 8388608]`, () => {
       const point = view.wgs84ToWorld([0, 0]);
       assert.ok(point instanceof Array);
-      assert.closeTo(point[0], 128);
-      assert.closeTo(point[1], 128);
+      assert.closeTo(point[0], 8388608);
+      assert.closeTo(point[1], 8388608);
     });
 
     it(`Projects [-180°, 85.0511287798°] -> [0, 0]`, () => {
       const point = view.wgs84ToWorld([-180, 85.0511287798]);
       assert.ok(point instanceof Array);
       assert.closeTo(point[0], 0);
-      assert.closeTo(point[1], 0);
+      assert.closeTo(point[1], 0, 1e-3);  // small residual at polar boundary
     });
 
-    it(`Projects [-180°, -85.0511287798°] -> [0, 256]`, () => {
+    it(`Projects [-180°, -85.0511287798°] -> [0, 16777216]`, () => {
       const point = view.wgs84ToWorld([-180, -85.0511287798]);
       assert.ok(point instanceof Array);
       assert.closeTo(point[0], 0);
-      assert.closeTo(point[1], 256);
+      assert.closeTo(point[1], 16777216, 1e-3);  // small residual at polar boundary
     });
 
-    it(`Projects [180°, 85.0511287798°] -> [256, 0]`, () => {
+    it(`Projects [180°, 85.0511287798°] -> [16777216, 0]`, () => {
       const point = view.wgs84ToWorld([180, 85.0511287798]);
       assert.ok(point instanceof Array);
-      assert.closeTo(point[0], 256);
-      assert.closeTo(point[1], 0);
+      assert.closeTo(point[0], 16777216);
+      assert.closeTo(point[1], 0, 1e-3);  // small residual at polar boundary
     });
 
-    it(`Projects [180°, -85.0511287798°] -> [256, 256]`, () => {
+    it(`Projects [180°, -85.0511287798°] -> [16777216, 16777216]`, () => {
       const point = view.wgs84ToWorld([180, 85.0511287798]);
       assert.ok(point instanceof Array);
-      assert.closeTo(point[0], 256);
-      assert.closeTo(point[1], 0);
+      assert.closeTo(point[0], 16777216);
+      assert.closeTo(point[1], 0, 1e-3);  // small residual at polar boundary
     });
 
-    it(`Projects out of bounds [-270°, 95°] -> [-64, 0]`, () => {
+    it(`Projects out of bounds [-270°, 95°] -> [-4194304, 0]`, () => {
       const point = view.wgs84ToWorld([-270, 95]);
       assert.ok(point instanceof Array);
-      assert.closeTo(point[0], -64);   // wrap x
-      assert.closeTo(point[1], 0);     // clamp y
+      assert.closeTo(point[0], -4194304);   // wrap x
+      assert.closeTo(point[1], 0, 1e-3);   // clamp y (small residual at polar boundary)
     });
 
-    it(`Projects out of bounds [270°, -95°] -> [320, 256]`, () => {
+    it(`Projects out of bounds [270°, -95°] -> [20971520, 16777216]`, () => {
       const point = view.wgs84ToWorld([270, -95]);
       assert.ok(point instanceof Array);
-      assert.closeTo(point[0], 320);   // wrap x
-      assert.closeTo(point[1], 256);   // clamp y
+      assert.closeTo(point[0], 20971520);          // wrap x
+      assert.closeTo(point[1], 16777216, 1e-3);   // clamp y (small residual at polar boundary)
     });
   });
 
@@ -233,8 +233,8 @@ describe('math/viewport', () => {
   describe('#worldToWgs84', () => {
     const view = new Viewport();
 
-    it(`Unprojects [128, 128] -> [0°, 0°]`, () => {
-      const point = view.worldToWgs84([128, 128]);
+    it(`Unprojects [8388608, 8388608] -> [0°, 0°]`, () => {
+      const point = view.worldToWgs84([8388608, 8388608]);
       assert.ok(point instanceof Array);
       assert.closeTo(point[0], 0);
       assert.closeTo(point[1], 0);
@@ -247,36 +247,36 @@ describe('math/viewport', () => {
       assert.closeTo(point[1], 85.0511287798);
     });
 
-    it(`Unprojects [0, 256] -> [-180°, -85.0511287798°]`, () => {
-      const point = view.worldToWgs84([0, 256]);
+    it(`Unprojects [0, 16777216] -> [-180°, -85.0511287798°]`, () => {
+      const point = view.worldToWgs84([0, 16777216]);
       assert.ok(point instanceof Array);
       assert.closeTo(point[0], -180);
       assert.closeTo(point[1], -85.0511287798);
     });
 
-    it(`Unprojects [256, 0] -> [180°, 85.0511287798°]`, () => {
-      const point = view.worldToWgs84([256, 0]);
+    it(`Unprojects [16777216, 0] -> [180°, 85.0511287798°]`, () => {
+      const point = view.worldToWgs84([16777216, 0]);
       assert.ok(point instanceof Array);
       assert.closeTo(point[0], 180);
       assert.closeTo(point[1], 85.0511287798);
     });
 
-    it(`Unprojects [256, 256] -> [180°, -85.0511287798°]`, () => {
-      const point = view.worldToWgs84([256, 256]);
+    it(`Unprojects [16777216, 16777216] -> [180°, -85.0511287798°]`, () => {
+      const point = view.worldToWgs84([16777216, 16777216]);
       assert.ok(point instanceof Array);
       assert.closeTo(point[0], 180);
       assert.closeTo(point[1], -85.0511287798);
     });
 
-    it(`Unprojects out of bounds [-64, -64] -> [-270°, 85.0511287798°]`, () => {
-      const point = view.worldToWgs84([-64, -64]);
+    it(`Unprojects out of bounds [-4194304, -4194304] -> [-270°, 85.0511287798°]`, () => {
+      const point = view.worldToWgs84([-4194304, -4194304]);
       assert.ok(point instanceof Array);
       assert.closeTo(point[0], -270);           // wrap x
       assert.closeTo(point[1], 85.0511287798);  // clamp y
     });
 
-    it(`Unprojects out of bounds [320, 320] -> [270°, -85.0511287798°] -> `, () => {
-      const point = view.worldToWgs84([320, 320]);
+    it(`Unprojects out of bounds [20971520, 20971520] -> [270°, -85.0511287798°] -> `, () => {
+      const point = view.worldToWgs84([20971520, 20971520]);
       assert.ok(point instanceof Array);
       assert.closeTo(point[0], 270);             // wrap x
       assert.closeTo(point[1], -85.0511287798);  // clamp y
@@ -544,22 +544,22 @@ describe('math/viewport', () => {
     //  define the north-up coordinate system (F is bottom-left, H is top-right)
     //
     const tests = {
-      '0':    [[28, 53], [228, 203]],
-      '45':   [[4.256313292354179, 4.256313292354193], [251.743686707645, 251.7436867076458]],
-      '90':   [[53, 28], [203, 228]],
-      '135':  [[4.256313292354179, 4.256313292354193], [251.743686707645, 251.7436867076458]],
-      '180':  [[28, 53], [228, 203]],
-      '225':  [[4.256313292354179, 4.256313292354193], [251.743686707645, 251.7436867076458]],
-      '270':  [[53, 28], [203, 228]],
-      '315':  [[4.256313292354179, 4.256313292354193], [251.743686707645, 251.7436867076458]],
-      '360':  [[28, 53], [228, 203]],
-      '-315': [[4.256313292354179, 4.256313292354193], [251.743686707645, 251.7436867076458]],
-      '-270': [[53, 28], [203, 228]],
-      '-225': [[4.256313292354179, 4.256313292354193], [251.743686707645, 251.7436867076458]],
-      '-180': [[28, 53], [228, 203]],
-      '-135': [[4.256313292354179, 4.256313292354193], [251.743686707645, 251.7436867076458]],
-      '-90':  [[53, 28], [203, 228]],
-      '-45':  [[4.256313292354179, 4.256313292354193], [251.743686707645, 251.7436867076458]]
+      '0':    [[1835008, 3473408], [14942208, 13303808]],
+      '45':   [[278941.74792772345, 278941.7479277244], [16498274.252072223, 16498274.252072275]],
+      '90':   [[3473408, 1835008], [13303808, 14942208]],
+      '135':  [[278941.74792772345, 278941.7479277244], [16498274.252072223, 16498274.252072275]],
+      '180':  [[1835008, 3473408], [14942208, 13303808]],
+      '225':  [[278941.74792772345, 278941.7479277244], [16498274.252072223, 16498274.252072275]],
+      '270':  [[3473408, 1835008], [13303808, 14942208]],
+      '315':  [[278941.74792772345, 278941.7479277244], [16498274.252072223, 16498274.252072275]],
+      '360':  [[1835008, 3473408], [14942208, 13303808]],
+      '-315': [[278941.74792772345, 278941.7479277244], [16498274.252072223, 16498274.252072275]],
+      '-270': [[3473408, 1835008], [13303808, 14942208]],
+      '-225': [[278941.74792772345, 278941.7479277244], [16498274.252072223, 16498274.252072275]],
+      '-180': [[1835008, 3473408], [14942208, 13303808]],
+      '-135': [[278941.74792772345, 278941.7479277244], [16498274.252072223, 16498274.252072275]],
+      '-90':  [[3473408, 1835008], [13303808, 14942208]],
+      '-45':  [[278941.74792772345, 278941.7479277244], [16498274.252072223, 16498274.252072275]]
     };
 
     for (const [key, expected] of Object.entries(tests)) {
@@ -571,10 +571,10 @@ describe('math/viewport', () => {
 
         const result = view.visibleWorldExtent();
         assert.ok(result instanceof Extent);
-        assert.closeTo(result.min[0], expected[0][0]);
-        assert.closeTo(result.min[1], expected[0][1]);
-        assert.closeTo(result.max[0], expected[1][0]);
-        assert.closeTo(result.max[1], expected[1][1]);
+        assert.closeTo(result.min[0], expected[0][0], 1);  // world coords are large; allow 1-unit tolerance
+        assert.closeTo(result.min[1], expected[0][1], 1);
+        assert.closeTo(result.max[0], expected[1][0], 1);
+        assert.closeTo(result.max[1], expected[1][1], 1);
       });
     }
   });


### PR DESCRIPTION
This PR redefines the "world" coordinate system that we added #297 to pre-scale the coordinate up to z16.

## Background

Previously, `wgs84ToWorld()` produced coordinates in the 0..256 range (zoom 0). Converting world → screen then required:

```
scale = 2^z
screenX = (worldX - 128) * scale + translateX
```

This means every cached world coordinate must be multiplied by `2^z` on every frame, at every zoom level.

## What this changes

World coordinates are now pre-scaled to **zoom 16**, giving a range of **0..16,777,216** (= 256 × 2^16).  The transform becomes:

```
scale = 2^(z - 16)
screenX = (worldX - 8_388_608) * scale + translateX
```

Key property: at z16 the scale is exactly **1.0** — world coordinates *are* pixel-perfect screen coordinates with no transform needed.

## Motivation

Editors like [Rapid](https://github.com/rapideditor/rapid) project GeoJSON geometry **once** and cache the result as world coordinates, then render that cache every frame. With z0 world coords, this cached geometry must still be reprojected into screen coordinates for rendering.

By pre-scaling to z16  (much closer to the zooms that we actually render the geometry at), 
- World -> screen can simply be performed as a multiply or GPU transform
- Preserves a useful amount of floating point precision (i.e. details specified in pixels like dash lines or line widths are not infinitesimally small). 
- Can avoid recomputing and storing another bunch of coordinate arrays and other supporting data on every change in zoom.
- This is especially helpful for Pixi.js pipelines where geometry is uploaded to the GPU once.

## API compatibility

`project()` / `unproject()` compose `wgs84ToWorld + worldToScreen` (and inverses). These methods remain **numerically invariant** — all callers of `project`/`unproject` continue to work unchanged.

`Tile.tileExtent` values are now in z16 world space (0..16,777,216) instead of z0 (0..256).

