### PR TITLE
fix(math): geomLineIntersection returns null when segments share a start point

### DIFF
--- a/packages/math/src/geom.ts
+++ b/packages/math/src/geom.ts
@@ -220,7 +220,7 @@ export function geomLineIntersection(
   const uNumerator = qpx * ry - qpy * rx;
   const denominator = rx * sy - ry * sx;
 
-  if (uNumerator && denominator) {
+  if (denominator) {
     const u = uNumerator / denominator;
     const t = (qpx * sy - qpy * sx) / denominator;   // t,u are intersection factors along segments a and b
 

--- a/packages/math/test/geom.test.ts
+++ b/packages/math/test/geom.test.ts
@@ -266,6 +266,16 @@ describe('math/geom', () => {
       const b: Vec2[] = [[-5, 10], [-5, -10]];
       expect(math.geomLineIntersection(a, b)).toBe(null);
     });
+
+    it('returns the shared endpoint when a0 and b0 are coincident', () => {
+      //  a0/b0 --- a1
+      //    |
+      //    b1
+      const a: Vec2[] = [[-122.1518608, 47.5080034000001], [-122.15185512809126, 47.508048302611435]];
+      const b: Vec2[] = [[-122.1518608, 47.5080034000001], [-122.1518365, 47.5080005]];
+      const result = math.geomLineIntersection(a, b);
+      expect(result).toEqual([-122.1518608, 47.5080034000001]);
+    });
   });
 
   describe('geomPathIntersections', () => {


### PR DESCRIPTION
## Problem

`geomLineIntersection` returned `null` when `a0` and `b0` are the same point, even though the intersection is well-defined (it's that shared point).

**Root cause:** when `a0 === b0`, both `qpx` and `qpy` are `0`, so `uNumerator = 0`. The condition:

```ts
if (uNumerator && denominator) {
```

treated a falsy `uNumerator` as a reason to skip the check entirely — but `u = 0` is a perfectly valid intersection parameter (the intersection is at `t = 0, u = 0`, i.e. the shared start point).

## Fix

Only gate on `denominator` (which being zero means the segments are parallel). A zero `uNumerator` simply means `u = 0`, which is within the valid `[0, 1]` range.

```ts
// before
if (uNumerator && denominator) {

// after
if (denominator) {
```

## Test

Added a regression test using real-world geographic coordinates where `a0` and `b0` are coincident.